### PR TITLE
fixtures.json, błąd z linii 417, brak nawiasu

### DIFF
--- a/joggertester/fixtures.json
+++ b/joggertester/fixtures.json
@@ -414,7 +414,8 @@
         "codename": "delete_site",
         "name": "Can delete site",
         "content_type": 6
-    }, {
+    }
+}, {
     "pk": 1,
     "model": "joggertester.kategoria",
     "fields": {


### PR DESCRIPTION
w nawiązaniu do:
https://github.com/d33tah/joggerpl-tools/commit/ada94421b9b3f73cc2dd25ffe855fec4b483b972

wyrzucało błąd poprawności pliku, bo zrobiłem błąd w nawiasach, 
ach to pisanie w przeglądarce i robienie commitu przed sprawdzeniem :D
