### PR TITLE
Update fixtures.json

### DIFF
--- a/joggertester/fixtures.json
+++ b/joggertester/fixtures.json
@@ -420,7 +420,7 @@
     "model": "joggertester.kategoria",
     "fields": {
         "href_descr": "kategoria_pierwsza",
-        "name": "Kategoria pierwsza"
+        "title": "Kategoria pierwsza"
     }
 }, {
     "pk": 2,


### PR DESCRIPTION
Kategorie mają pole "title", chociaż jedna miała "name". 
Powodowało to błąd wgrywania fiksturek.