### PR TITLE
Quick fix for SSL redirects

### DIFF
--- a/wordpress-import/main.py
+++ b/wordpress-import/main.py
@@ -42,7 +42,14 @@ socket.getaddrinfo = memoize(socket.getaddrinfo)
 class Main(object):
 
     def main(self, url, login, password, path):
-        self.client = wordpress_xmlrpc.Client(url, login, password)
+        try: 
+            self.client = wordpress_xmlrpc.Client(url, login, password)
+        except wordpress_xmlrpc.exceptions.ServerConnectionError as exc:
+            if '301 Moved Permanently' in exc.args[0]:
+                print("301 redirect, trying HTTPS protocol.")
+                ssl_url = url.replace('http://', 'https://')
+                self.client = wordpress_xmlrpc.Client(ssl_url, login, password)
+            
         # This is just to make sure that the credentials are OK before we jump
         # to XML parsing.
         self.client.call(wordpress_xmlrpc.methods.users.GetUsers())


### PR DESCRIPTION
Szybki fix na błąd, który zgłaszała siwa. Pewnie ładniej by było testować wstępnie linka i ewentualnie łapać `Location` z redirecta ale to chyba przerost formy nad treścią. Ewentualnie można drukować bardziej zrozumiały komunikat o błędzie, ale po co, skoro można zaryzykować, spróbować HTTPSa i dopiero wtedy się wywalić, gdy też nie wyjdzie.
